### PR TITLE
Fix bug related to typeform Url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'django-appconf',
         'django-model-utils',
         'djangorestframework',
-        'psycopg2',
+        'psycopg2-binary',
         'redis',
     ],
     license="MIT",

--- a/typeform_feedback/__init__.py
+++ b/typeform_feedback/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'typeform_feedback.apps.TypeformFeedbackConfig'
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/typeform_feedback/models/generic_typeform.py
+++ b/typeform_feedback/models/generic_typeform.py
@@ -50,7 +50,7 @@ class GenericTypeformFeedback(TimeStampedModel):
             object_id=linked_object.pk,
             quiz_slug=slug,
             typeform_id=typeform_id,
-            url=kwargs.get('url', settings.TYPEFORM_FEEDBACK_DEFAULT_URL.format(typeform_id))
+            url=kwargs.get('url', None) or settings.TYPEFORM_FEEDBACK_DEFAULT_URL.format(typeform_id)
         )
         new_typeform.save()
         return new_typeform


### PR DESCRIPTION
## Problem

Fix a bug when creating a new typeform object without url. The url was not correctly stored

## Solution

Fixed with a default value if was not url specified.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
