### PR TITLE
Add API endpoint to get typeform url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
 script:
   - tox
-  - sonar-scanner
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,12 @@ services:
 addons:
   sonarcloud:
     organization: openexo
-install: 
+install:
   - pip install -r requirements_test.txt
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
 script:
   - tox
-  - sonar-scanner
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,6 @@ django-typeform-feedback
 
 .. image:: https://codecov.io/gh/exolever/django-typeform-feedback/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/exolever/django-typeform-feedback
-
-.. image:: https://sonarcloud.io/api/project_badges/measure?project=exolever_django-typeform-feedback&metric=alert_status
-   :target: https://sonarcloud.io/dashboard?id=exolever_django-typeform-feedback
   
 .. image:: https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat
    :target: https://github.com/exolever/django-typeform-feedback/issues

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.projectKey=exolever_django-typeform-feedback
-sonar.organization=openexo
-sonar.host.url=https://sonarcloud.io
-sonar.projectVersion=0.1.0
-sonar.sources=typeform_feedback
-sonar.exclusions=**/tests/**, **/static/**/template/**, **/migrations/**, **/__pycache__/**, **/admin.py

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,7 +51,7 @@ if django.VERSION >= (1, 10):
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
     )
 else:
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE_CLASSES = [
         'django.middleware.security.SecurityMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
@@ -59,7 +59,7 @@ else:
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    )
+    ]
 
 TEMPLATES = [
     {

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,17 +31,35 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sites',
-    'typeform_feedback',
+    'django.contrib.sessions',
+    'rest_framework.authtoken',
     'rest_framework',
+    'typeform_feedback',
     'foo',
 ]
 
 SITE_ID = 1
 
 if django.VERSION >= (1, 10):
-    MIDDLEWARE = ()
+    MIDDLEWARE = (
+        'django.middleware.security.SecurityMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    )
 else:
-    MIDDLEWARE_CLASSES = ()
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.security.SecurityMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    )
 
 TEMPLATES = [
     {

--- a/typeform_feedback/__init__.py
+++ b/typeform_feedback/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'typeform_feedback.apps.TypeformFeedbackConfig'
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'

--- a/typeform_feedback/api/serializers.py
+++ b/typeform_feedback/api/serializers.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from ..models import UserGenericTypeformFeedback
+from ..models import UserGenericTypeformFeedback, GenericTypeformFeedback
 
 
 class UserResponseValidationSerializer(serializers.ModelSerializer):
@@ -37,3 +37,18 @@ class UserResponseKOSerializer(UserResponseValidationSerializer):
 
     def update(self, instance, validated_data):
         instance.mark_as_fail()
+
+
+class GenericTypeformUrlSerializer(serializers.ModelSerializer):
+
+    url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = GenericTypeformFeedback
+        fields = ['url']
+
+    def get_url(self, obj):
+        return '{}?user_id={}'.format(
+            obj.url,
+            self.context.get('request').user.pk
+        )

--- a/typeform_feedback/api/urls.py
+++ b/typeform_feedback/api/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url, include
 
 from rest_framework.routers import DefaultRouter
 
-from .views import UserTypeformViewSet
+from .views import UserTypeformViewSet, GenericTypeformApiView
 
 app_name = 'typeform_feedback'
 
@@ -11,4 +11,5 @@ router.register(r'', UserTypeformViewSet, base_name='action')
 
 urlpatterns = [
     url(r'^action/', include(router.urls)),
+    url(r'^get/(?P<quiz_slug>\w+)/', GenericTypeformApiView.as_view(), name='get-url'),
 ]

--- a/typeform_feedback/api/views/__init__.py
+++ b/typeform_feedback/api/views/__init__.py
@@ -1,0 +1,2 @@
+from .user_generic_typeform import UserTypeformViewSet  # noqa
+from .generic_typeform import GenericTypeformApiView    # noqa

--- a/typeform_feedback/api/views/generic_typeform.py
+++ b/typeform_feedback/api/views/generic_typeform.py
@@ -1,0 +1,14 @@
+from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated
+
+from ...models import GenericTypeformFeedback
+from ..serializers import GenericTypeformUrlSerializer
+
+
+class GenericTypeformApiView(generics.RetrieveAPIView):
+
+    serializer_class = GenericTypeformUrlSerializer
+    permission_classes = (IsAuthenticated, )
+    lookup_field = 'quiz_slug'
+    lookup_url_kwarg = 'quiz_slug'
+    queryset = GenericTypeformFeedback.objects.all()

--- a/typeform_feedback/api/views/user_generic_typeform.py
+++ b/typeform_feedback/api/views/user_generic_typeform.py
@@ -3,8 +3,8 @@ from rest_framework.decorators import action
 
 from rest_framework.response import Response
 
-from ..models import UserGenericTypeformFeedback
-from .serializers import (
+from ...models import UserGenericTypeformFeedback
+from ..serializers import (
     UserResponseValidationSerializer,
     UserResponseOKSerializer,
     UserResponseKOSerializer,


### PR DESCRIPTION
## Problem

Add new API endpoint

## Solution

To make easy get the real Typeform url we have created a new endpoint which return the final url

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
